### PR TITLE
Keep routing vtex.io to landing page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "io-landing",
-  "version": "1.2.0",
+  "version": "1.2.1-beta.0",
   "title": "VTEX IO landing page",
   "description": "VTEX IO landing page",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "io-landing",
-  "version": "1.2.1-beta.0",
+  "version": "1.2.1-beta.1",
   "title": "VTEX IO landing page",
   "description": "VTEX IO landing page",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "io-landing",
-  "version": "1.2.1-beta.1",
+  "version": "1.2.1-beta.2",
   "title": "VTEX IO landing page",
   "description": "VTEX IO landing page",
   "builders": {

--- a/react/package.json
+++ b/react/package.json
@@ -22,6 +22,6 @@
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-intl": "^2.4.0",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1369,10 +1369,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uri-js@^4.2.2:
   version "4.2.2"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -7,6 +7,9 @@
   "io.landing": {
     "component": "IO"
   },
+  "io.landing-old": {
+    "component": "IO"
+  },
   "io.faq": {
     "component": "FAQ"
   },

--- a/store/routes.json
+++ b/store/routes.json
@@ -4,7 +4,7 @@
     "cname": "www.vtex.io"
   },
   "io.landing-old": {
-    "path": "/io",
+    "path": "/io-old",
     "cname": "vtex.io"
   },
   "io.faq": {

--- a/store/routes.json
+++ b/store/routes.json
@@ -3,6 +3,10 @@
     "path": "/io",
     "cname": "www.vtex.io"
   },
+  "io.landing-old": {
+    "path": "/io",
+    "cname": "vtex.io"
+  },
   "io.faq": {
     "path": "/faq"
   },


### PR DESCRIPTION
This will keep both domains working for a while
while we finish the full migration to www.vtex.io

Fixes this error we are getting in the landing page of https://vtex.io/ :
```
{
code: "NotFound",
message: "Route vtex.io/ not found",
source: "Vtex.Kube.Router",
requestId: "b023341c59ea4a329d461cc3d4927a11"
}
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
