### PR TITLE
Route to SFJ Onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Route to redirect to SFJ Onboarding
+
 ## [1.2.1] - 2020-04-29
 
 ## [1.2.0] - 2020-04-28

--- a/react/OnboardingSFJ.tsx
+++ b/react/OnboardingSFJ.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, FunctionComponent, Fragment } from 'react'
+import { useRuntime } from 'vtex.render-runtime'
+import { urls } from './constants/URLs'
+
+const OnboardingSFJ: FunctionComponent = () => {
+  const {
+    query: { account, code, state },
+  } = useRuntime()
+
+  useEffect(() => {
+    if (account && code && state) {
+      window.location.assign(`${urls.SFJ_ONBOARDING_PAGE(account)}?account=${account}&code=${code}&state=${state}`)
+    }
+  }, [code, account, state])
+
+  return <Fragment></Fragment>
+}
+
+export default OnboardingSFJ

--- a/react/constants/URLs.ts
+++ b/react/constants/URLs.ts
@@ -1,0 +1,4 @@
+export const urls = {
+  SFJ_ONBOARDING_PAGE: (account: string) =>
+    `https://faststore--${account}.myvtex.com/admin/app/sfj/onboarding/create-github-repo`,
+}

--- a/react/package.json
+++ b/react/package.json
@@ -22,6 +22,6 @@
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-intl": "^2.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   }
 }

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -22,8 +22,11 @@ declare module 'vtex.render-runtime' {
       emit: (eventName: string, eventId: string) => void
     }
     query: {
-      app: string
+      app?: string
       filePath?: string
+      account?: string
+      code?: string
+      state?: string
     }
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1369,10 +1369,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uri-js@^4.2.2:
   version "4.2.2"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -15,5 +15,8 @@
   },
   "io.store-features": {
     "component": "Features"
+  },
+  "io.sfj-onboarding": {
+    "component": "OnboardingSFJ"
   }
 }

--- a/store/routes.json
+++ b/store/routes.json
@@ -12,5 +12,8 @@
   },
   "io.store-features": {
     "path": "/store-features"
+  },
+  "io.sfj-onboarding": {
+    "path": "/sfj-onboarding"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add new route that only redirects to SFJ Onboarding.

#### What problem is this solving?
We need a public route to be the callback URL of GitHub authorization process, required on the SFJ Onboarding.
The Onboarding is formed by admin routes on the client’s account, but we also need one public route to put on the GitHub callback URL. This callback URL should be static (not change from account to account) and be public.

#### How should this be manually tested?
https://vtex.io/sfj-onboarding?workspace=faststore&account=vtexgame2&code=cd14a0160005ae&state=e886-494d-b348-fa751ec2466f
This should redirect to an admin page on vtexgame2 account

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
