### PR TITLE
Change Onboarding naming and route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- SFJ Onboarding naming and route
 
 ## [1.3.0] - 2021-06-22
 

--- a/react/Onboarding.tsx
+++ b/react/Onboarding.tsx
@@ -2,18 +2,18 @@ import React, { useEffect, FunctionComponent, Fragment } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { urls } from './constants/URLs'
 
-const OnboardingSFJ: FunctionComponent = () => {
+const Onboarding: FunctionComponent = () => {
   const {
     query: { account, code, state },
   } = useRuntime()
 
   useEffect(() => {
     if (account && code && state) {
-      window.location.assign(`${urls.SFJ_ONBOARDING_PAGE(account)}?account=${account}&code=${code}&state=${state}`)
+      window.location.assign(`${urls.STOREFRONT_ONBOARDING_PAGE(account)}?account=${account}&code=${code}&state=${state}`)
     }
   }, [code, account, state])
 
   return <Fragment></Fragment>
 }
 
-export default OnboardingSFJ
+export default Onboarding

--- a/react/constants/URLs.ts
+++ b/react/constants/URLs.ts
@@ -1,4 +1,4 @@
 export const urls = {
-  SFJ_ONBOARDING_PAGE: (account: string) =>
-    `https://faststore--${account}.myvtex.com/admin/app/sfj/onboarding/create-github-repo`,
+  STOREFRONT_ONBOARDING_PAGE: (account: string) =>
+    `https://faststore--${account}.myvtex.com/admin/app/storefront/onboarding/create-github-repo`,
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -16,7 +16,7 @@
   "io.store-features": {
     "component": "Features"
   },
-  "io.sfj-onboarding": {
-    "component": "OnboardingSFJ"
+  "io.storefront-onboarding": {
+    "component": "Onboarding"
   }
 }

--- a/store/routes.json
+++ b/store/routes.json
@@ -13,7 +13,7 @@
   "io.store-features": {
     "path": "/store-features"
   },
-  "io.sfj-onboarding": {
-    "path": "/sfj-onboarding"
+  "io.storefront-onboarding": {
+    "path": "/storefront-onboarding"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the Onboarding route

#### What problem is this solving?
It was decided a better (and generic) naming to this onboarding route, [here](https://github.com/vtex/onboarding-automation/pull/2#discussion_r661713319).

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
